### PR TITLE
Fix pipeline/split function

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,32 +1,33 @@
 name: Rust
-
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
-
-env:
-  CARGO_TERM_COLOR: always
-
+  push:
+    branches: [ main ]
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup 
-      uses: actions-rs/toolchain@v1
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
       with:
-        toolchain: stable
-        override: true
-        components: rustfmt, clippy 
-    - name: Build
-      run: cargo build
-    - name: Test
-      run: cargo test -- --nocapture
-    - name: Build (all features)
-      run: cargo build --all-features
-    - name: Test (all features)
-      run: cargo test --all-features -- --nocapture
-    - name: Coding style
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          ~/.rustup
+          /usr/local/cargo
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Install Rust
+      run: rustup update stable
+    - name: Run rustfmt
       run: cargo fmt --all -- --check
+    - name: Run clippy
+      run: cargo clippy --all -- -D warnings
+    - uses: taiki-e/install-action@nextest
+    - name: Cargo Test
+      run: cargo nextest run --all-features --no-capture --no-fail-fast

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,7 +422,6 @@ impl Unit {
             Ok(t) => t,
             Err(e) => panic!("For {:?} -> {e}", name_raw),
         };
-        let mut docs: Vec<Doc> = Vec::with_capacity(3);
         let mut is_doc = false;
         for line in lines {
             let line = line.trim_start();
@@ -456,7 +455,7 @@ impl Unit {
             } else if let Some(line) = line.strip_prefix("Docs: ") {
                 is_doc = true;
                 if let Ok(doc) = Doc::from_str(line) {
-                    docs.push(doc)
+                    u.docs.get_or_insert_with(Vec::new).push(doc);
                 }
             } else if let Some(line) = line.strip_prefix("What: ") {
                 // mountpoint infos
@@ -498,7 +497,7 @@ impl Unit {
                 if is_doc {
                     let line = line.trim_start();
                     if let Ok(doc) = Doc::from_str(line) {
-                        docs.push(doc)
+                        u.docs.get_or_insert_with(Vec::new).push(doc);
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,13 +629,7 @@ mod test {
             let c0 = unit.chars().nth(0).unwrap();
             if c0.is_alphanumeric() {
                 // valid unit name --> run test
-                let u = match Unit::from_systemctl(&unit) {
-                    Ok(x) => x,
-                    Err(e) => {
-                        println!("Could not parse {unit} -> {e}");
-                        continue;
-                    },
-                };
+                let u = Unit::from_systemctl(&unit).unwrap();
                 println!("####################################");
                 println!("Unit: {:#?}", u);
                 println!("active: {}", u.active);


### PR DESCRIPTION
## Changes

### Fixes
* When splitting Unit Type from Unitname it should split the right most `.` so Units with dots in the name correctly split.
* Docs where previously ignored in the last commit, this will fix it.

### Improvements
* Update Github Actions to use `cargo nextest run` [nextest](https://nexte.st/index.html)
* Update Github Actions to cache dependencies, this will reduce pipeline runtime by a lot