### PR TITLE
Implement Errorhandling for Exitstatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,18 @@ if let Ok(true) = systemctl::exists("ntpd") {
 ```rust
 use systemctl;
 // list all units
-systemctl::list_units(None, None);
+systemctl::list_units(None, None, None);
 
 // list all services 
 // by adding a --type filter
-systemctl::list_units(Some("service"), None);
+systemctl::list_units(Some("service"), None, None);
 
 // list all services currently `enabled` 
 // by adding a --state filter
-systemctl::list_units(Some("service"), Some("enabled"));
+systemctl::list_units(Some("service"), Some("enabled"), None);
+
+// list all services starting with cron
+systemctl::list_units(Some("service"), None, Some("cron*"));
 ```
 
 ## Unit structure
@@ -83,6 +86,3 @@ println!("Memory consumption: {}", unit.memory.unwrap());
 ## TODO
 
 * [ ] parse all known attributes in `from_systemctl`
-* [ ] currently we study (try to parse) stdio result from systemctl() invokation,
-without testing the exit status, which is bad. This is due to the fact
-that we get apparently get an error code, on existing units that currently have a `dead` state


### PR DESCRIPTION
## Changes

### Features
* implement exit code handling for `systemctl_capture()` -> from testing I found 0,1,3,4 that are used. More will hopefully come up on usage
* add `start()`, `enable()`, `disable()` on crate level and for `Unit`
* add `stop()`, `exists()` for `Unit`, it was still missing

### Other
* put spawn part of `systemctl()` and `systemctl_capture()` into its own function `spawn_child()` to reduce duplicate code
* reduce `if let hell` and use `?` operator more
* add more tests and improve error tests (`PartialEq` on structs was needed for this)
* updated readme to reflect additional filter option on `list_units()`