### PR TITLE
Add serde and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+     
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+        - dependency-name: "semver"
+        - dependency-name: "crates-io"
+    rebase-strategy: "disabled"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,3 +31,9 @@ jobs:
     - uses: taiki-e/install-action@nextest
     - name: Cargo Test
       run: cargo nextest run --all-features --no-capture --no-fail-fast
+    - name: auto-merge Dependabot
+      if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+      run: |
+        gh pr merge --merge $GITHUB_HEAD_REF
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,14 @@ homepage = "https://github.com/gwbres/systemctl"
 edition = "2021"
 readme = "README.md"
 
+[features]
+default = []
+
 [dependencies]
 strum = "0.25"
 strum_macros = "0.25"
 itertools = "0.11"
+serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
## Changes
* add: serde derives, this way applications using this lib don't have to re-create structs, but can use the ones provided.
* add: Dependabot to check for dependencies once a week
* add: If a pipeline triggered by dependabot (and only dependabot!) dependency update is successful, it will automerge
* add: serde tests
* fix: UnitList is no longer seen as dead code by clippy, so remove the warning suppressor

## Comment
Hi, I'm using serde_json to convert the provided data to json and send it via http. Until now I had to re-implement all structs, with this merge, I can reduce my code by a lot. For the dependabot change, it will keep the crate up to date without any work (unless a dependency has a breaking change). All you need to do is a release every once in a while.