### PR TITLE
Add serde to cargo.toml, improve readme, test clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [features]
 default = []
+serde = ["dep:serde"]
 
 [dependencies]
 strum = "0.25"

--- a/README.md
+++ b/README.md
@@ -4,10 +4,18 @@ Small rust crate to interact with systemd units
 
 [![crates.io](https://img.shields.io/crates/v/systemctl.svg)](https://crates.io/crates/systemctl)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/gwbres/systemctl/blob/main/LICENSE-APACHE)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/systemctl/blob/main/LICENSE-MIT) 
-[![crates.io](https://img.shields.io/crates/d/systemctl.svg)](https://crates.io/crates/systemctl)   
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](https://github.com/gwbres/systemctl/blob/main/LICENSE-MIT)
+[![crates.io](https://img.shields.io/crates/d/systemctl.svg)](https://crates.io/crates/systemctl)  
 [![Rust](https://github.com/gwbres/systemctl/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/gwbres/systemctl/actions/workflows/rust.yml)
 [![crates.io](https://docs.rs/systemctl/badge.svg)](https://docs.rs/systemctl/badge.svg)
+
+## Features
+
+* serde: Enable to make structs in this crate De-/Serializable
+
+## Limitations
+
+Currently SystemD Version <245 are not supported as unit-file-list changed from two column to three column setup. See: [SystemD Changelog](https://github.com/systemd/systemd/blob/16bfb12c8f815a468021b6e20871061d20b50f57/NEWS#L6073)
 
 ## Environment
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,7 +685,7 @@ mod test {
     #[test]
     fn test_non_existing_unit() {
         let unit = Unit::from_systemctl("non-existing");
-        assert!(unit.is_err().clone());
+        assert!(unit.is_err());
         let result = unit.map_err(|e| e.kind());
         let expected = Err(ErrorKind::NotFound);
         assert_eq!(expected, result);
@@ -702,7 +702,7 @@ mod test {
     fn test_systemctl_exitcode_not_found() {
         let u = Unit::from_systemctl("cran.service");
         println!("{:#?}", u);
-        assert!(u.is_err().clone());
+        assert!(u.is_err());
         let result = u.map_err(|e| e.kind());
         let expected = Err(ErrorKind::NotFound);
         assert_eq!(expected, result);
@@ -713,15 +713,15 @@ mod test {
         let units = list_units(None, None, None).unwrap(); // all units
         for unit in units {
             let unit = unit.as_str();
-            if unit.contains("@") {
+            if unit.contains('@') {
                 // not testing this one
                 // would require @x service # identification / enumeration
                 continue;
             }
-            let c0 = unit.chars().nth(0).unwrap();
+            let c0 = unit.chars().next().unwrap();
             if c0.is_alphanumeric() {
                 // valid unit name --> run test
-                let u = Unit::from_systemctl(&unit).unwrap();
+                let u = Unit::from_systemctl(unit).unwrap();
                 println!("####################################");
                 println!("Unit: {:#?}", u);
                 println!("active: {}", u.active);


### PR DESCRIPTION
## Changes

### Fixes
* add `serde` as feature in Cargo.toml so it becomes testable with `--all-features` (was usable before, but you would need to know the feature exists)

### Other
* clippy: fix tests
* readme: add feature section
* readme: add limitation of systemd version