### PR TITLE
my 0.4 suggestion: allow passing e.g. `--user` args, don't use env-vars, refactor to struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,13 @@ readme = "README.md"
 [features]
 default = []
 serde = ["dep:serde"]
-args = ["dep:shlex"]
 
 [dependencies]
 strum = "0.26"
 strum_macros = "0.26"
 itertools = "0.13"
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
-shlex = { version = "1.3", optional = true }
+bon="2.3"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,14 @@ readme = "README.md"
 [features]
 default = []
 serde = ["dep:serde"]
+args = ["dep:shlex"]
 
 [dependencies]
 strum = "0.25"
 strum_macros = "0.25"
 itertools = "0.11"
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+shlex = { version = "1.3", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ serde = ["dep:serde"]
 args = ["dep:shlex"]
 
 [dependencies]
-strum = "0.25"
-strum_macros = "0.25"
-itertools = "0.11"
+strum = "0.26"
+strum_macros = "0.26"
+itertools = "0.13"
 serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
 shlex = { version = "1.3", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "systemctl"
-version = "0.3.1"
+version = "0.4.0"
 license = "MIT OR Apache-2.0"
 authors = ["Guillaume W. Bres <guillaume.bressaix@gmail.com>"]
 description = "Small crate to interact with systemd units"

--- a/README.md
+++ b/README.md
@@ -17,28 +17,19 @@ Small rust crate to interact with systemd units
 
 Currently SystemD Version <245 are not supported as unit-file-list changed from two column to three column setup. See: [SystemD Changelog](https://github.com/systemd/systemd/blob/16bfb12c8f815a468021b6e20871061d20b50f57/NEWS#L6073)
 
-## Environment
-
-`SYSTEMCTL_PATH` custom env. variable describes the absolute
-location path of `systemctl` binary, by default this crate uses `/usr/bin/systemctl`,
-but that can be customized:
-
-```shell
-SYSTEMCTL_PATH=/home/$me/bin/systemctl cargo build
-```
-
 ## Unit / service operation
 
 Nominal service operations:
 
 ```rust
-systemctl::stop("systemd-journald.service")
+let systemctl = systemctl::SystemCtl::default();
+systemctl.stop("systemd-journald.service")
     .unwrap();
-systemctl::restart("systemd-journald.service")
+systemctl.restart("systemd-journald.service")
     .unwrap();
 
-if let Ok(true) = systemctl::exists("ntpd") {
-    let is_active = systemctl::is_active("ntpd")
+if let Ok(true) = systemctl.exists("ntpd") {
+    let is_active = systemctl.is_active("ntpd")
         .unwrap();
 }
 ```
@@ -46,20 +37,20 @@ if let Ok(true) = systemctl::exists("ntpd") {
 ## Service enumeration
 
 ```rust
-use systemctl;
+let systemctl = systemctl::SystemCtl::default();
 // list all units
-systemctl::list_units(None, None, None);
+systemctl.list_units(None, None, None);
 
 // list all services 
 // by adding a --type filter
-systemctl::list_units(Some("service"), None, None);
+systemctl.list_units(Some("service"), None, None);
 
 // list all services currently `enabled` 
 // by adding a --state filter
-systemctl::list_units(Some("service"), Some("enabled"), None);
+systemctl.list_units(Some("service"), Some("enabled"), None);
 
 // list all services starting with cron
-systemctl::list_units(Some("service"), None, Some("cron*"));
+systemctl.list_units(Some("service"), None, Some("cron*"));
 ```
 
 ## Unit structure
@@ -67,9 +58,10 @@ systemctl::list_units(Some("service"), None, Some("cron*"));
 Use the unit structure for more information
 
 ```rust
-let unit = systemctl::Unit::from_systemctl("sshd")
+let systemctl = systemctl::SystemCtl::default();
+let unit = systemctl.create_unit("ssh.service")
     .unwrap();
-unit.restart().unwrap();
+systemctl.restart(&unit.name).unwrap();
 println!("active: {}", unit.active);
 println!("preset: {}", unit.preset);
 
@@ -84,11 +76,11 @@ if let Some(docs) = unit.docs { // doc pages available
     }
 }
 
-println!("auto_start (enabled): {}", unit.auto_start);
+println!("auto_start (enabled): {:?}", unit.auto_start);
 println!("config script : {}", unit.script);
-println!("pid: {}", unit.pid);
-println!("Running task(s): {}", unit.tasks.unwrap());
-println!("Memory consumption: {}", unit.memory.unwrap());
+println!("pid: {:?}", unit.pid);
+println!("Running task(s): {:?}", unit.tasks);
+println!("Memory consumption: {:?}", unit.memory);
 ```
 
 ## TODO

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! Crate to manage and monitor services through `systemctl`   
 //! Homepage: <https://github.com/gwbres/systemctl>
+#![doc=include_str!("../README.md")] 
 use std::io::{Error, ErrorKind, Read};
 use std::process::{Child, ExitStatus};
 use std::str::FromStr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,11 @@ impl SystemCtl {
         ))
     }
 
+    /// Reloads all unit files
+    pub fn daemon_reload(&self) -> std::io::Result<ExitStatus> {
+        self.systemctl(["daemon-reload"])
+    }
+
     /// Forces given `unit` to (re)start
     pub fn restart(&self, unit: &str) -> std::io::Result<ExitStatus> {
         self.systemctl(["restart", unit])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,21 +13,24 @@ const SYSTEMCTL_PATH: &str = "/usr/bin/systemctl";
 use bon::Builder;
 
 /// Struct with API calls to systemctl.
-/// 
+///
 /// Use the `::default()` impl if you don't need special arguments.
-/// 
+///
 /// Use the builder API when you want to specify a custom path to systemctl binary or extra args.
 #[derive(Builder, Default, Clone, Debug)]
 pub struct SystemCtl {
     /// Allows passing global arguments to systemctl like `--user`.
     additional_args: Vec<String>,
     /// The path to the systemctl binary, by default it's [SYSTEMCTL_PATH]
-    path: Option<String>
+    path: Option<String>,
 }
 
 impl SystemCtl {
     /// Invokes `systemctl $args`
-    fn spawn_child<'a, 's: 'a, S: IntoIterator<Item = &'a str>>(&'s self, args: S) -> std::io::Result<Child> {
+    fn spawn_child<'a, 's: 'a, S: IntoIterator<Item = &'a str>>(
+        &'s self,
+        args: S,
+    ) -> std::io::Result<Child> {
         std::process::Command::new(self.get_path())
             .args(self.additional_args.iter().map(String::as_str).chain(args))
             .stdout(std::process::Stdio::piped())
@@ -40,12 +43,18 @@ impl SystemCtl {
     }
 
     /// Invokes `systemctl $args` silently
-    fn systemctl<'a, 's: 'a, S: IntoIterator<Item = &'a str>>(&'s self, args: S) -> std::io::Result<ExitStatus> {
+    fn systemctl<'a, 's: 'a, S: IntoIterator<Item = &'a str>>(
+        &'s self,
+        args: S,
+    ) -> std::io::Result<ExitStatus> {
         self.spawn_child(args)?.wait()
     }
 
     /// Invokes `systemctl $args` and captures stdout stream
-    fn systemctl_capture<'a, 's: 'a, S: IntoIterator<Item = &'a str>>(&'s self, args: S) -> std::io::Result<String> {
+    fn systemctl_capture<'a, 's: 'a, S: IntoIterator<Item = &'a str>>(
+        &'s self,
+        args: S,
+    ) -> std::io::Result<String> {
         let mut child = self.spawn_child(args)?;
         match child.wait()?.code() {
             Some(0) => {}, // success
@@ -176,7 +185,7 @@ impl SystemCtl {
     ///  + state filter: optional `--state` filter
     ///  + glob filter: optional unit name filter
     pub fn list_units_full(
-        &self, 
+        &self,
         type_filter: Option<&str>,
         state_filter: Option<&str>,
         glob: Option<&str>,
@@ -391,7 +400,6 @@ pub struct UnitList {
     /// Unit vendor preset
     pub vendor_preset: Option<bool>,
 }
-
 
 /// `AutoStartStatus` describes the Unit current state
 #[derive(Copy, Clone, PartialEq, Eq, EnumString, Debug, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Crate to manage and monitor services through `systemctl`   
 //! Homepage: <https://github.com/gwbres/systemctl>
-#![doc=include_str!("../README.md")] 
+#![doc=include_str!("../README.md")]
 use std::io::{Error, ErrorKind, Read};
 use std::process::{Child, ExitStatus};
 use std::str::FromStr;


### PR DESCRIPTION
- refactored to `SystemCtl` struct instead of functions
  - allows passing path to systemctl binary without using env vars
    - allows multiple instances running with different binaries at the same time
  - allows passing custom args to systemctl, like using it in `--user` mode
  - used `bon` crate to provide `SystemCtl::builder()` api
  - use `SystemCtl::default()` api to use like in previous versions without changing any arguments
- performance
  - don't use `Vec`s unnecessarily when `Command.args()` requires `IntoIterator` it's enough to pass iterators or const arrays
- bumped version to 0.4
- updated versions of dependencies
- run tests and they are passing
- added some docs and fixed clippy lints  
- removed Unit duplicated `fn`s like `restart` etc. simply use `Unit`'s name on the `SystemCtl` struct `fn`s