### PR TITLE
Implement 'list-units' systemctl call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,4 +862,3 @@ mod test {
         assert_eq!(u, reverse);
     }
 }
-


### PR DESCRIPTION
I needed to see if services were running or had failed and that was not possible using the `list-unit-files` call. So I added it!

It has breaking changes. `list_units` and `list_units_full` has been renamed to `list_unit_files` and `list_unit_files_full` respectively. I renamed them to reflect their appropriate calls, and because I couldn't think of a better function name for `systemctl list-units` :) 

I can rename them to avoid breaking changes, just not sure what to call them.

Closes https://github.com/gwbres/systemctl/issues/32