### PR TITLE
Fix issues with '--all' argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,8 @@ impl SystemCtl {
         args: S,
     ) -> std::io::Result<String> {
         let mut child = self.spawn_child(args)?;
-        match child.wait()?.code() {
+        let output = child.wait_with_output()?;
+        match output.status.code() {
             Some(0) => {}, // success
             Some(1) => {}, // success -> Ok(Unit not found)
             Some(3) => {}, // success -> Ok(unit is inactive and/or dead)
@@ -83,8 +84,8 @@ impl SystemCtl {
             },
         }
 
-        let mut stdout: Vec<u8> = Vec::new();
-        let size = child.stdout.unwrap().read_to_end(&mut stdout)?;
+        let mut stdout: Vec<u8> = output.stdout;
+        let size = stdout.len();
 
         if size > 0 {
             if let Ok(s) = String::from_utf8(stdout) {


### PR DESCRIPTION
This pull request fixes two issues I had with using the '--all' argument with list-units():

1. there was a deadlock, so the output would never arrive
2. the output for units in the state 'not_found' was messed up, because the unit name is then prefixed by '● '