### PR TITLE
Correct systemd spelling according to match definition on freedesktop…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Small rust crate to interact with systemd units
 
 ## Limitations
 
-Currently SystemD Version <245 are not supported as unit-file-list changed from two column to three column setup. See: [SystemD Changelog](https://github.com/systemd/systemd/blob/16bfb12c8f815a468021b6e20871061d20b50f57/NEWS#L6073)
+Currently, systemd Version <245 are not supported as unit-file-list changed from two column to three column setup. See: [systemd Changelog](https://github.com/systemd/systemd/blob/16bfb12c8f815a468021b6e20871061d20b50f57/NEWS#L6073)
 
 ## Unit / service operation
 


### PR DESCRIPTION
The [project website states](https://www.freedesktop.org/wiki/Software/systemd/) explicitly how to write the sstemd name:

_[...] it is written systemd, not system D or System D, or even SystemD. And it isn't system d either. Why? Because it's a system daemon, and under Unix/Linux those are in lower case, and get suffixed with a lower case d. And since systemd manages the system, it's called systemd._

Kindly accept my PR to adjust the writing of systemd in the README.md