### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 license = "MIT OR Apache-2.0"
 authors = ["Guillaume W. Bres <guillaume.bressaix@gmail.com>"]
 description = "Small crate to interact with systemd units"
-homepage = "https://github.com/gwbres/systemctl"
+repository = "https://github.com/gwbres/systemctl"
 edition = "2021"
 readme = "README.md"
 


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91